### PR TITLE
Configurable channel (left/right)

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ i2s:
   dma_buf_count: 8              # default: 8
   dma_buf_len: 256              # default: 256
   use_apll: true                # default: false
+  channel: right                # default: left
 
   # right shift samples.
   # for example if mic has 24 bit resolution, and

--- a/README.md
+++ b/README.md
@@ -26,7 +26,12 @@ i2s:
   dma_buf_count: 8              # default: 8
   dma_buf_len: 256              # default: 256
   use_apll: true                # default: false
-  channel: right                # default: left
+
+  # according to datasheet when L/R pin is connected to GND,
+  # the mic should output its signal in the left channel,
+  # however in my experience it's the opposite: when I connect
+  # L/R to GND then the signal is in the right channel
+  channel: right                # default: right
 
   # right shift samples.
   # for example if mic has 24 bit resolution, and

--- a/components/i2s/__init__.py
+++ b/components/i2s/__init__.py
@@ -22,6 +22,14 @@ CONF_DMA_BUF_COUNT = "dma_buf_count"
 CONF_DMA_BUF_LEN = "dma_buf_len"
 CONF_USE_APLL = "use_apll"
 CONF_BITS_SHIFT = "bits_shift"
+CONF_CHANNEL = "channel"
+
+
+i2s_channel_fmt_t = cg.global_ns.enum("i2s_channel_fmt_t")
+CHANNELS = {
+    "left": i2s_channel_fmt_t.I2S_CHANNEL_FMT_ONLY_LEFT,
+    "right": i2s_channel_fmt_t.I2S_CHANNEL_FMT_ONLY_RIGHT,
+}
 
 CONFIG_SCHEMA = cv.All(
     cv.Schema(
@@ -37,6 +45,7 @@ CONFIG_SCHEMA = cv.All(
             cv.Optional(CONF_DMA_BUF_LEN, 256): cv.positive_not_null_int,
             cv.Optional(CONF_USE_APLL, False): cv.boolean,
             cv.Optional(CONF_BITS_SHIFT, 0): cv.int_range(0, 32),
+            cv.Optional(CONF_CHANNEL, default="left"): cv.enum(CHANNELS),        
         }
     ).extend(cv.COMPONENT_SCHEMA),
     cv.has_at_least_one_key(CONF_DIN_PIN, CONF_DOUT_PIN),
@@ -64,3 +73,4 @@ async def to_code(config):
     cg.add(var.set_dma_buf_len(config[CONF_DMA_BUF_LEN]))
     cg.add(var.set_use_apll(config[CONF_USE_APLL]))
     cg.add(var.set_bits_shift(config[CONF_BITS_SHIFT]))
+    cg.add(var.set_channel(config[CONF_CHANNEL]))

--- a/components/i2s/__init__.py
+++ b/components/i2s/__init__.py
@@ -45,7 +45,7 @@ CONFIG_SCHEMA = cv.All(
             cv.Optional(CONF_DMA_BUF_LEN, 256): cv.positive_not_null_int,
             cv.Optional(CONF_USE_APLL, False): cv.boolean,
             cv.Optional(CONF_BITS_SHIFT, 0): cv.int_range(0, 32),
-            cv.Optional(CONF_CHANNEL, default="left"): cv.enum(CHANNELS),        
+            cv.Optional(CONF_CHANNEL, default="right"): cv.enum(CHANNELS),
         }
     ).extend(cv.COMPONENT_SCHEMA),
     cv.has_at_least_one_key(CONF_DIN_PIN, CONF_DOUT_PIN),

--- a/components/i2s/i2s.cpp
+++ b/components/i2s/i2s.cpp
@@ -22,6 +22,7 @@ bool I2SComponent::get_use_apll() const { return this->use_apll_; }
 void I2SComponent::set_bits_shift(uint8_t bits_shift) { this->bits_shift_ = bits_shift; }
 uint8_t I2SComponent::get_bits_shift() const { return this->bits_shift_; }
 float I2SComponent::get_setup_priority() const { return setup_priority::BUS; }
+void I2SComponent::set_channel(i2s_channel_fmt_t channel) { this->channel_ = channel; }
 
 void I2SComponent::dump_config() {
   ESP_LOGCONFIG(TAG, "I2S %d:", this->port_num_);
@@ -35,6 +36,7 @@ void I2SComponent::dump_config() {
   ESP_LOGCONFIG(TAG, "  DMA Buf Len: %u", this->dma_buf_len_);
   ESP_LOGCONFIG(TAG, "  Use APLL: %s", YESNO(this->use_apll_));
   ESP_LOGCONFIG(TAG, "  Bits Shift: %u", this->bits_shift_);
+  ESP_LOGCONFIG(TAG, "  Channel: %02X", this->channel_);
 }
 
 bool I2SComponent::read(uint8_t *data, size_t len, size_t *bytes_read, TickType_t ticks_to_wait) {
@@ -130,7 +132,7 @@ void I2SComponent::setup() {
   i2s_config_t i2s_config = {.mode = i2s_mode_t(I2S_MODE_MASTER | I2S_MODE_RX),  // TODO: make it configurable
                              .sample_rate = this->sample_rate_,
                              .bits_per_sample = i2s_bits_per_sample_t(this->bits_per_sample_),
-                             .channel_format = I2S_CHANNEL_FMT_ONLY_RIGHT,  // TODO: make it configurable
+                             .channel_format = this->channel_,
                              .communication_format = I2S_COMM_FORMAT_STAND_I2S,
                              .intr_alloc_flags = ESP_INTR_FLAG_LEVEL1,
                              .dma_buf_count = this->dma_buf_count_,

--- a/components/i2s/i2s.cpp
+++ b/components/i2s/i2s.cpp
@@ -36,7 +36,10 @@ void I2SComponent::dump_config() {
   ESP_LOGCONFIG(TAG, "  DMA Buf Len: %u", this->dma_buf_len_);
   ESP_LOGCONFIG(TAG, "  Use APLL: %s", YESNO(this->use_apll_));
   ESP_LOGCONFIG(TAG, "  Bits Shift: %u", this->bits_shift_);
-  ESP_LOGCONFIG(TAG, "  Channel: %02X", this->channel_);
+  ESP_LOGCONFIG(TAG, "  Channel: %s",
+                this->channel_ == I2S_CHANNEL_FMT_ONLY_RIGHT  ? "right"
+                : this->channel_ == I2S_CHANNEL_FMT_ONLY_LEFT ? "left"
+                                                              : "invalid");
 }
 
 bool I2SComponent::read(uint8_t *data, size_t len, size_t *bytes_read, TickType_t ticks_to_wait) {
@@ -129,7 +132,7 @@ void I2SComponent::setup() {
 
   ESP_LOGCONFIG(TAG, "Setting up I2S %u ...", this->port_num_);
 
-  i2s_config_t i2s_config = {.mode = i2s_mode_t(I2S_MODE_MASTER | I2S_MODE_RX),  // TODO: make it configurable
+  i2s_config_t i2s_config = {.mode = i2s_mode_t(I2S_MODE_MASTER | I2S_MODE_RX),
                              .sample_rate = this->sample_rate_,
                              .bits_per_sample = i2s_bits_per_sample_t(this->bits_per_sample_),
                              .channel_format = this->channel_,

--- a/components/i2s/i2s.h
+++ b/components/i2s/i2s.h
@@ -33,6 +33,7 @@ class I2SComponent : public Component {
   bool read_samples(int16_t *data, size_t num_samples, size_t *samples_read, TickType_t ticks_to_wait = portMAX_DELAY);
   bool read_samples(float *data, size_t num_samples, size_t *samples_read, TickType_t ticks_to_wait = portMAX_DELAY);
   bool read_samples(std::vector<float> &data, TickType_t ticks_to_wait = portMAX_DELAY);
+  void set_channel(i2s_channel_fmt_t channel);
   virtual void setup() override;
   virtual void dump_config() override;
   virtual float get_setup_priority() const override;
@@ -50,6 +51,7 @@ class I2SComponent : public Component {
   int dma_buf_len_{256};
   bool use_apll_{false};
   uint8_t bits_shift_{0};
+  i2s_channel_fmt_t channel_{0x00}; // left
 };
 }  // namespace i2s
 }  // namespace esphome

--- a/components/i2s/i2s.h
+++ b/components/i2s/i2s.h
@@ -51,7 +51,7 @@ class I2SComponent : public Component {
   int dma_buf_len_{256};
   bool use_apll_{false};
   uint8_t bits_shift_{0};
-  i2s_channel_fmt_t channel_{0x00}; // left
+  i2s_channel_fmt_t channel_{I2S_CHANNEL_FMT_ONLY_RIGHT};
 };
 }  // namespace i2s
 }  // namespace esphome

--- a/configs/advanced-example-config.yaml
+++ b/configs/advanced-example-config.yaml
@@ -23,6 +23,7 @@ i2s:
   dma_buf_count: 8              # default: 8
   dma_buf_len: 256              # default: 256
   use_apll: true                # default: false
+  channel: right                 # default: left
 
   # right shift samples.
   # for example if mic has 24 bit resolution, and

--- a/configs/advanced-example-config.yaml
+++ b/configs/advanced-example-config.yaml
@@ -23,7 +23,12 @@ i2s:
   dma_buf_count: 8              # default: 8
   dma_buf_len: 256              # default: 256
   use_apll: true                # default: false
-  channel: right                 # default: left
+
+  # according to datasheet when L/R pin is connected to GND,
+  # the mic should output its signal in the left channel,
+  # however in my experience it's the opposite: when I connect
+  # L/R to GND then the signal is in the right channel
+  channel: right                # default: right
 
   # right shift samples.
   # for example if mic has 24 bit resolution, and

--- a/configs/sensor-community-example-config.yaml
+++ b/configs/sensor-community-example-config.yaml
@@ -55,6 +55,7 @@ i2s:
   dma_buf_len: 256
   use_apll: true
   bits_shift: 8
+  channel: right
 
 sound_level_meter:
   update_interval: 150s  # to match original sensor.community firmware settings


### PR DESCRIPTION
Made the channel configurable in the YAML. I'm unfamiliair with the python code so for that I looked at the official esphome for an example: https://github.com/esphome/esphome/tree/dev/esphome/components/i2s_audio/microphone

I've tested it with my setup and when the right channel is selected, I'm around 75 dB(A), I supect that is noise since my other decibel meter says the room is around 41 (quiet empty office). With the left channel selected I'm around 43 dB(A).