### PR TITLE
Minor changes to support ESP32-S6 and esphome 2025.2.2 

### DIFF
--- a/components/i2s/i2s.cpp
+++ b/components/i2s/i2s.cpp
@@ -143,7 +143,7 @@ void I2SComponent::setup() {
                              .use_apll = this->use_apll_,
                              .tx_desc_auto_clear = false,
                              .fixed_mclk = 0,
-                             .mclk_multiple = I2S_MCLK_MULTIPLE_DEFAULT,
+                             .mclk_multiple = I2S_MCLK_MULTIPLE_256,
                              .bits_per_chan = i2s_bits_per_chan_t(0)};
 
   i2s_pin_config_t i2s_pin_config = {

--- a/components/i2s/i2s.cpp
+++ b/components/i2s/i2s.cpp
@@ -30,7 +30,7 @@ void I2SComponent::dump_config() {
   LOG_PIN("  BCK Pin: ", this->bck_pin_);
   LOG_PIN("  DIN Pin: ", this->din_pin_);
   LOG_PIN("  DOUT Pin: ", this->dout_pin_);
-  ESP_LOGCONFIG(TAG, "  Sample Rate: %u", this->sample_rate_);
+  ESP_LOGCONFIG(TAG, "  Sample Rate: %lu", this->sample_rate_);
   ESP_LOGCONFIG(TAG, "  Bits Per Sample: %u", this->bits_per_sample_);
   ESP_LOGCONFIG(TAG, "  DMA Buf Count: %u", this->dma_buf_count_);
   ESP_LOGCONFIG(TAG, "  DMA Buf Len: %u", this->dma_buf_len_);

--- a/components/sound_level_meter/sound_level_meter.cpp
+++ b/components/sound_level_meter/sound_level_meter.cpp
@@ -1,4 +1,5 @@
 #include "sound_level_meter.h"
+#include "esp_timer.h"
 
 namespace esphome {
 namespace sound_level_meter {

--- a/components/sound_level_meter/sound_level_meter.cpp
+++ b/components/sound_level_meter/sound_level_meter.cpp
@@ -37,8 +37,8 @@ optional<float> SoundLevelMeter::get_offset() { return this->offset_; }
 void SoundLevelMeter::dump_config() {
   ESP_LOGCONFIG(TAG, "Sound Level Meter:");
   ESP_LOGCONFIG(TAG, "  Buffer Size: %u (samples)", this->buffer_size_);
-  ESP_LOGCONFIG(TAG, "  Warmup Interval: %u ms", this->warmup_interval_);
-  ESP_LOGCONFIG(TAG, "  Task Stack Size: %u", this->task_stack_size_);
+  ESP_LOGCONFIG(TAG, "  Warmup Interval: %lu ms", this->warmup_interval_);
+  ESP_LOGCONFIG(TAG, "  Task Stack Size: %lu", this->task_stack_size_);
   ESP_LOGCONFIG(TAG, "  Task Priority: %u", this->task_priority_);
   ESP_LOGCONFIG(TAG, "  Task Core: %u", this->task_core_);
   LOG_UPDATE_INTERVAL(this);
@@ -117,7 +117,7 @@ void SoundLevelMeter::task(void *param) {
       auto sr = this_->get_sample_rate();
       if (process_count >= sr * (this_->update_interval_ / 1000.f)) {
         auto t = uint32_t(float(process_time) / process_count * (sr / 1000.f));
-        ESP_LOGD(TAG, "Processing time per 1s of audio data (%u samples): %u ms", sr, t);
+        ESP_LOGD(TAG, "Processing time per 1s of audio data (%lu samples): %lu ms", sr, t);
         process_time = process_count = 0;
       }
     }


### PR DESCRIPTION
It would be safest to test this against some existing configs and platformio versions before merging to main, but the changes themselves seem pretty harmless. Mostly compiler noise due to more strict options during build - I'm not sure when that changed.

For reference I'm using one of these:
https://www.waveshare.com/esp32-c6-lcd-1.47.htm

Build config:
```yaml
esp32:
  board: esp32-c6-devkitc-1
  flash_size: 4MB
  variant: esp32c6
  framework:
    type: esp-idf
    version: 5.3.1
    platform_version: 6.9.0
```

Note for future readers: you will need to set `task_core: 0` on the `sound_level_meter` config, as the S6 has only a single CPU core.

To test you have to make sure you're referencing the branch named in this PR. In this case it's from my fork:

```yaml
external_components:
  - source: github://mafrosis/esphome-sound-level-meter@tmp
    components: [i2s, sound_level_meter]
```